### PR TITLE
Add slug to Bundle

### DIFF
--- a/api/bundle/models/bundle.settings.json
+++ b/api/bundle/models/bundle.settings.json
@@ -44,6 +44,9 @@
     },
     "ImageAltText_FR": {
       "type": "string"
+    },
+    "slug": {
+      "type": "uid"
     }
   }
 }


### PR DESCRIPTION
# Description

Missed adding this field in another PR. The slug is used to help with the import, to make it easier to fetch the correct bundle id.
