### PR TITLE
Fixing storage class for new dts deployment model

### DIFF
--- a/helmfile/overrides/strapi-psql.yaml.gotmpl
+++ b/helmfile/overrides/strapi-psql.yaml.gotmpl
@@ -2,17 +2,9 @@ image:
   tag: 11.9.0
 persistence:
     enabled: true
-    {{- if or (eq .Environment.Name "prod-blue") (eq .Environment.Name "prod-green") }}
     storageClass: dtsstorageclass
-    {{- else }}
-    storageClass: dtsstorageclass-dev
-    {{- end }}
 global:
-    {{- if or (eq .Environment.Name "prod-blue") (eq .Environment.Name "prod-green") }}
     storageClass: dtsstorageclass
-    {{- else }}
-    storageClass: dtsstorageclass-dev
-    {{- end }}
 postgresqlUsername: "{{ requiredEnv "STRAPI_DATABASE_USERNAME" }}"
 postgresqlPassword: "{{ requiredEnv "STRAPI_DATABASE_PASSWORD" }}"
 postgresqlDatabase: "{{ requiredEnv "STRAPI_DATABASE_NAME" }}"


### PR DESCRIPTION
# Description

Removed logic around storage class in helmfile overrides. The new deployment model to K8s uses a single storage class regardless of which environment you're in.
